### PR TITLE
Add option to store object when pushing intervals

### DIFF
--- a/lib/intervals.js
+++ b/lib/intervals.js
@@ -8,10 +8,11 @@
 module.exports.Interval = Interval;
 module.exports.IntervalStack = IntervalStack;
 
-function Interval(from, to) {
+function Interval(from, to, obj) {
   this.id = ++Interval.prototype.id;
   this.from = from;
   this.to = to;
+  this.obj = obj;
 }
 
 Interval.prototype.id = 0;
@@ -22,7 +23,7 @@ Interval.prototype.INTERSECT_OR_SUPERSET = 3;
 
 Interval.prototype.compareTo = function(other) {
   if (other.from > this.to || other.to < this.from) return this.DISJOINT;
-  if (other.from <= this.from && other.to >= this.to) return this.SUBSET; 
+  if (other.from <= this.from && other.to >= this.to) return this.SUBSET;
   return this.INTERSECT_OR_SUPERSET;
 }
 
@@ -65,12 +66,12 @@ function _validateInterval(from, to) {
   };
 }
 
-function _validateIntervalArray(from, to) {
-  if (!(from instanceof Array && to instanceof Array)) throw {
+function _validateIntervalArray(from, to, properties) {
+  if (!(from instanceof Array && to instanceof Array && properties instanceof Array)) throw {
     name: 'InvalidParameter',
     message: 'function pushArray: parameters must be arrays'
   };
-  if (from.length !== to.length) throw {
+  if (from.length !== to.length || from.length !== properties.length) throw {
     name: 'InvalidParameter',
     message: 'function pushArray: arrays must have same length'
   };
@@ -100,16 +101,16 @@ function _validatePointArray(points) {
 }
 
 
-function pushInterval(from, to) {
+function pushInterval(from, to, obj) {
   _validateInterval(from, to);
-  this._intervals.push(new Interval(from, to));
+  this._intervals.push(new Interval(from, to, obj));
 }
 
-function pushArray(from, to, validate) {
+function pushArray(from, to, properties, validate) {
   var val = (validate !== undefined) ? validate : true;
-  if (val) _validateIntervalArray(from, to);
+  if (val) _validateIntervalArray(from, to, properties);
   for(var i = 0; i < from.length; i++) {
-    this._intervals.push(new Interval(from[i], to[i]));
+    this._intervals.push(new Interval(from[i], to[i], properties[i]));
   }
 }
 
@@ -150,4 +151,3 @@ function queryIntervalArray(from, to, options) {
   }
   return this._queryInterval(intervalArray, resFn, disjointFn);
 }
-


### PR DESCRIPTION
Option to pass an object when pushing intervals (can be used to store ID or
any other properties), really useful when querying points, intervals or
overlaps.

tree.pushInterval( 10, 20, { prop1 : 'Could be anything' , id : 500 } );

tree.pushArray( fromValues , toValues , [
				      { propFromObj1 : 'value' },
				      { propFromObj2 : 'value' },
				      { propFromObj3 : 'value' }
				    ]);